### PR TITLE
Fixed typo in card documentation

### DIFF
--- a/src/docs/components/Card.tsx
+++ b/src/docs/components/Card.tsx
@@ -29,7 +29,7 @@ function CardDocs() {
 
   const cardProps = [
     {
-      name: 'iteractive',
+      name: 'interactive',
       type: 'boolean',
       description: `Whether the card should respond to user interactions. If set to true, hovering over the card will increase the card's elevation`,
     },


### PR DESCRIPTION
Just noticed this typo while taking a look at the docs. Looks like a good project, I like the style.